### PR TITLE
Added the include and link directories where CycloneDDS is installed to in ROS 2

### DIFF
--- a/dds/build.rs
+++ b/dds/build.rs
@@ -9,6 +9,8 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
         .clang_arg("-I/usr/local/include")
+        .clang_arg("-I/opt/ros/eloquent/include")
+        .clang_arg("-I/usr/lib/gcc/x86_64-linux-gnu/8/include")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/dds/build.rs
+++ b/dds/build.rs
@@ -5,11 +5,16 @@ use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rustc-link-lib=ddsc");
+    println!("cargo:rustc-link-search=/opt/ros/foxy/lib/x86_64-linux-gnu");
+    println!("cargo:rustc-link-search=/opt/ros/eloquent/lib");
+    println!("cargo:rustc-link-search=/opt/ros/dashing/lib");
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
         .clang_arg("-I/usr/local/include")
+        .clang_arg("-I/opt/ros/foxy/include")
         .clang_arg("-I/opt/ros/eloquent/include")
+        .clang_arg("-I/opt/ros/dashing/include")
         .clang_arg("-I/usr/lib/gcc/x86_64-linux-gnu/8/include")
         .generate()
         .expect("Unable to generate bindings");


### PR DESCRIPTION
This adds the include and link directories for CycloneDDS in the ROS 2 distros that ship with CycloneDDS, this will need to be updated for every new ROS 2 distro.